### PR TITLE
Updated dependencies so this uses pug instead of jade

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ npm install --save simple-parse-smtp-adapter
 
 ### Use
 
-In the configuration of your parse server you must pass `simple-parse-smtp-adapter` as email adapter and set your SMTP access for send emails also the path to your jade template and its less file.
+In the configuration of your parse server you must pass `simple-parse-smtp-adapter` as email adapter and set your SMTP access for send emails also the path to your pug template and its less file.
 
 This is an example using parse server as express module:
 
@@ -76,7 +76,7 @@ app.listen(APP_PORT, function () {
 ```
 
 ### Template
-The path you pass to the email adapter must be a directory and not a file, this path must contain 2 mandatory files `html.jade` and `style.less` you can do your template as you like with the [CSS rules that emails supports](https://www.campaignmonitor.com/css/) in the template you can use 3 variables:
+The path you pass to the email adapter must be a directory and not a file, this path must contain 2 mandatory files `html.pug` and `style.less` you can do your template as you like with the [CSS rules that emails supports](https://www.campaignmonitor.com/css/) in the template you can use 3 variables:
 
 - appName //This is the name of your parse app
 - link //This is the link for reset the password

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 "use strict";
 const path = require('path');
 const nodemailer = require("nodemailer");
-const EmailTemplate = require('email-templates').EmailTemplate;
+const Email = require('email-templates');
 
 let SimpleParseSmtpAdapter = (adapterOptions) => {
     if (!adapterOptions || !adapterOptions.user || !adapterOptions.password || !adapterOptions.host || !adapterOptions.fromAddress ) {
@@ -51,18 +51,13 @@ let SimpleParseSmtpAdapter = (adapterOptions) => {
      */
     let renderTemplate = (template, data) => {
         let templateDir = template;
-        let html = new EmailTemplate(templateDir);
-
-        return new Promise((resolve, reject) => {
-            html.render(data, (err, result) => {
-                if (err) {
-                    console.log(err)
-                    reject(err);
-                } else {
-                    resolve(result);
-                }
-            });
+        let templateFile = "html";
+        
+        let html = new Email({
+            views: { root: templateDir }
         });
+        
+        return html.render(templateFile, data);
     };
 
     /**
@@ -104,7 +99,7 @@ let SimpleParseSmtpAdapter = (adapterOptions) => {
         if (adapterOptions.templates && adapterOptions.templates.resetPassword) {
 
             return renderTemplate(adapterOptions.templates.resetPassword.template, data).then((result) => {
-                mail.text = result.html;
+                mail.text = result;
                 mail.subject = adapterOptions.templates.resetPassword.subject;
 
                 return sendMail(mail);
@@ -135,9 +130,9 @@ let SimpleParseSmtpAdapter = (adapterOptions) => {
         };
 
         if (adapterOptions.templates && adapterOptions.templates.verifyEmail) {
-
+            
             return renderTemplate(adapterOptions.templates.verifyEmail.template, data).then((result) => {
-                mail.text = result.html;
+                mail.text = result;
                 mail.subject = adapterOptions.templates.verifyEmail.subject;
 
                 return sendMail(mail);

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "author": "Jose Luis <jose@lcortes.net> (http://lcortes.net)",
     "license": "MIT",
     "dependencies": {
-        "email-templates": "^2.4.1",
-        "jade": "^1.11.0",
-        "less": "^2.7.1",
-        "nodemailer": "^2.5.0",
-        "path": "^0.12.7"
+        "email-templates": "^3.3.4",
+        "less": "^3.0.0",
+        "nodemailer": "^4.4.2",
+        "path": "^0.12.7",
+        "pug": "^2.0.0-rc.4"
     }
 }


### PR DESCRIPTION
Jade has been renamed and moved to a project called [Pug](https://github.com/pugjs/pug).  This pull request updates the dependencies to use current versions including an update to [email-templates](https://github.com/niftylettuce/email-templates) from 2.x to 3.x.  The email-templates update had a few breaking API changes which have been addressed here. The documentation was also updates to reference pug instead of jade.

I've tested these changes in parse-server to try and make sure that everything still works as expected. The only thing to note is that you'll need to rename your template files from `html.jade` to `html.pug`.

Please let me know if you have any suggestions or concerns.